### PR TITLE
print a 3-column calendar

### DIFF
--- a/print a 3-column calendar
+++ b/print a 3-column calendar
@@ -1,0 +1,6 @@
+import calendar
+cal = calendar.TextCalendar(calendar.SUNDAY)
+# year: 2022, column width: 2, lines per week: 1 
+# number of spaces between month columns: 1
+# 3: no. of months per column.
+print(cal.formatyear(2022, 2, 1, 1, 3))


### PR DESCRIPTION
Write a Python program to print a 3-column calendar for an entire year.